### PR TITLE
Updated plugins versions and removed broken plugin. The javadoc plugin was throwing errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,71 @@
 java-utils
 ==========
 
-Java Utilities
+[![Build Status](https://travis-ci.org/eidoscode/java-utils.svg?branch=master)](https://travis-ci.org/eidoscode/java-utils)
+[![Build status](https://ci.appveyor.com/api/projects/status/v4fyhfqu23bcokfn/branch/master?svg=true)](https://ci.appveyor.com/project/antonini/java-utils/branch/master)
+
+The purpose of this project is to group utilities that are used on most of other Java projects.
+
+
+## Available Utilities
+
+### 1. Collection
+
+//... TODO
+
+### 2. Multithread
+
+//... TODO
+
+### 3. IO
+
+//... TODO
+
+#### 3.1. Stream 
+
+//... TODO
+
+#### 3.2. Zip
+
+//... TODO
+
+### 4. JAXRS
+
+//... TODO
+
+### 5. Resources
+
+//... TODO
+
+
+
+## Requirements
+
+* At least Java 7;
+* Apache Maven 3.3+ (developer);
+
+
+
+## How to contribute
+
+Fork repository, make changes, send a pull request. We are going to review your changes and apply them to the `master`.
+
+This project is created usign Apache Maven so check the requirements listed above to developers. 
+
+Before sending a pull request don't forget to run all unit tests:
+
+```
+$ mvn clean install
+```
+
+If your default encoding is not UTF-8, some of unit tests will break. This
+is an intentional behavior. To fix that, set this environment variable
+in console (in Windows, for example):
+
+```
+SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
+```
+
+## Bugs, Improvement or Questions?
+
+So, found a bug, want some improvement or just have a questions about how to do someting? Then [open an issue](https://github.com/eidoscode/java-utils/issues/new) an we will try to help you.

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -88,8 +88,44 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>1.8</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.18.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>2.5</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>2.7</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>2.5.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>2.6.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>2.5.3</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>2.10</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-release-plugin</artifactId>
+					<version>2.5.1</version>
+				</plugin>
+				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.10.3</version>
 					<configuration>
 						<use>true</use>
 						<version>true</version>
@@ -100,12 +136,11 @@
 							<link>http://www.eidoscode.com/</link>
 						</links>
 					</configuration>
-				</plugin>			
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
@@ -113,47 +148,20 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
-   			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.3</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<!-- 
 			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.3</version>
-				<configuration>
-					<docfilessubdirs>true</docfilessubdirs>
-					<excludedocfilessubdir>.svn</excludedocfilessubdir>
-					<encoding>UTF-8</encoding>
-					<docEncoding>UTF-8</docEncoding>
-				</configuration>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
 				<executions>
 					<execution>
 						<goals>
 							<goal>jar</goal>
-							<goal>javadoc</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>site</id>
-						<phase>pre-site</phase>
-						<goals>
-							<goal>javadoc</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
-			 -->
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5</version>
+				<version>2.5.1</version>
 			</plugin>
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
@@ -168,7 +176,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 
 			<plugin>
 				<artifactId>maven-site-plugin</artifactId>
@@ -193,7 +200,6 @@
 		<report>maven-cobertura-plugin</report>
 	</reports>
 
-
 	<reporting>
 		<plugins>
 			<plugin>
@@ -210,7 +216,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.6</version>
+				<version>2.8</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -231,20 +237,14 @@
 					</reportSet>
 				</reportSets>
 			</plugin>
-			<!-- 
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10</version>
-			</plugin>
-			 -->
 			<plugin>
 				<artifactId>maven-jxr-plugin</artifactId>
-				<version>2.3</version>
+				<version>2.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.5.2</version>
+				<version>2.6</version>
 				<configuration>
 					<formats>
 						<format>html</format>
@@ -253,9 +253,8 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-changes-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.11</version>
 				<configuration>
 					<columnNames>Id,Type,Summary,Assignee,Status,Fix Version</columnNames>
 					<includeOpenIssues>true</includeOpenIssues>
@@ -271,7 +270,6 @@
 						</reports>
 					</reportSet>
 				</reportSets>
-				<!-- -->
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -338,11 +336,11 @@
 					</tagListOptions>
 				</configuration>
 			</plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>1.3.1</version>
-      </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.2</version>
+			</plugin>
 		</plugins>
 	</reporting>
 </project>


### PR DESCRIPTION
- Updated plugins versions and removed broken plugin. The javadoc plugin was throwing errors.
- Improved the README file.
